### PR TITLE
Using activity_main instead of activity_main_for_screenshot as layout

### DIFF
--- a/app/src/main/java/de/uzl/itm/ncoap/android/server/MainActivity.java
+++ b/app/src/main/java/de/uzl/itm/ncoap/android/server/MainActivity.java
@@ -104,7 +104,7 @@ public class MainActivity extends AppCompatActivity implements RadioGroup.OnChec
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main_for_screenshot);
+        setContentView(R.layout.activity_main);
 
         //Initialize the action bar
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);


### PR DESCRIPTION
Hi,
Thanks for your repository.

I noticed you put `activity_main_for_screenshot` as layout of `MainActivity`, which makes your application buggy !

Have a nice day.